### PR TITLE
Скалярный DateTime для GraphQL.

### DIFF
--- a/modules/graphql/definition/DateTimeType.php
+++ b/modules/graphql/definition/DateTimeType.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types = 1);
+
+namespace app\modules\graphql\definition;
+
+use DateTime;
+use GraphQL\Language\AST\StringValueNode;
+use GraphQL\Type\Definition\ScalarType;
+use DateTimeInterface;
+use GraphQL\Error\InvariantViolation;
+use GraphQL\Utils\Utils;
+
+/**
+ * Class DateTimeType
+ * Реализация типа DateTime для GraphQL.
+ * @package app\modules\graphql\definition
+ */
+class DateTimeType extends ScalarType
+{
+	/**
+	 * @var string
+	 */
+	public $name = 'DateTime';
+
+	/**
+	 * @var string
+	 */
+	public $description = 'Тип DateTime для GraphQL';
+
+	private const DEFAULT_FORMAT = 'Y-m-d H:i:s';
+
+	/**
+	 * Сериализация входящих значений.
+	 * @param mixed $value
+	 * @return string
+	 */
+	public function serialize($value): string
+	{
+		if (!$value instanceof DateTimeInterface) {
+			throw new InvariantViolation(
+				'Входящие значение не соответствует DateTimeInterface: '
+				. Utils::printSafe($value)
+			);
+		}
+
+		return $value->format(self::DEFAULT_FORMAT);
+	}
+
+	/**
+	 * Преобразует входящее значение в формат по умолчанию.
+	 * @param mixed $value
+	 * @return DateTime|null
+	 */
+	public function parseValue($value): ?DateTime
+	{
+		return DateTime::createFromFormat(self::DEFAULT_FORMAT, $value) ?: null;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function parseLiteral($valueNode, ?array $variables = null): ?string
+	{
+		return $valueNode instanceof StringValueNode ? $valueNode->value : null;
+	}
+}

--- a/modules/graphql/definition/DateTimeType.php
+++ b/modules/graphql/definition/DateTimeType.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace app\modules\graphql\definition;
 
-use DateTime;
+use DateTimeImmutable;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Type\Definition\ScalarType;
 use DateTimeInterface;
@@ -13,6 +13,7 @@ use GraphQL\Utils\Utils;
 /**
  * Class DateTimeType
  * Реализация типа DateTime для GraphQL.
+ * Сделано на будущее, если ребята с фронта, захотят другой формат даты.
  * @package app\modules\graphql\definition
  */
 class DateTimeType extends ScalarType
@@ -25,7 +26,7 @@ class DateTimeType extends ScalarType
 	/**
 	 * @var string
 	 */
-	public $description = 'Тип DateTime для GraphQL';
+	public $description = 'Скалярный тип DateTime представляет данные даты и времени, в виде строки в формате ' . self::DEFAULT_FORMAT;
 
 	/**
 	 * @var ScalarType|null
@@ -53,11 +54,11 @@ class DateTimeType extends ScalarType
 	/**
 	 * Преобразует входящее значение в формат по умолчанию.
 	 * @param mixed $value
-	 * @return DateTime|null
+	 * @return DateTimeInterface|null
 	 */
-	public function parseValue($value): ?DateTime
+	public function parseValue($value): ?DateTimeInterface
 	{
-		return DateTime::createFromFormat(self::DEFAULT_FORMAT, $value) ?: null;
+		return DateTimeImmutable::createFromFormat(self::DEFAULT_FORMAT, $value) ?: null;
 	}
 
 	/**
@@ -74,5 +75,15 @@ class DateTimeType extends ScalarType
 	public static function dateTime(): ScalarType
 	{
 		return static::$dateTimeType ?? (static::$dateTimeType = new DateTimeType());
+	}
+
+	/**
+	 * Статичный метод для преобразования строк.
+	 * @param string|null $value
+	 * @return DateTimeImmutable|null
+	 */
+	public static function parseString(?string $value): ?DateTimeImmutable
+	{
+		return null !== $value ? DateTimeImmutable::createFromFormat(self::DEFAULT_FORMAT, $value) : null;
 	}
 }

--- a/modules/graphql/definition/DateTimeType.php
+++ b/modules/graphql/definition/DateTimeType.php
@@ -74,9 +74,6 @@ class DateTimeType extends ScalarType
 	 */
 	public static function dateTime(): ScalarType
 	{
-		if (null === static::$dateTimeType) {
-			static::$dateTimeType = new DateTimeType();
-		}
-		return static::$dateTimeType;
+		return static::$dateTimeType ?? (static::$dateTimeType = new DateTimeType());
 	}
 }

--- a/modules/graphql/definition/DateTimeType.php
+++ b/modules/graphql/definition/DateTimeType.php
@@ -27,6 +27,11 @@ class DateTimeType extends ScalarType
 	 */
 	public $description = 'Тип DateTime для GraphQL';
 
+	/**
+	 * @var ScalarType|null
+	 */
+	private static ?ScalarType $dateTimeType;
+
 	private const DEFAULT_FORMAT = 'Y-m-d H:i:s';
 
 	/**
@@ -62,5 +67,16 @@ class DateTimeType extends ScalarType
 	public function parseLiteral($valueNode, ?array $variables = null): ?string
 	{
 		return $valueNode instanceof StringValueNode ? $valueNode->value : null;
+	}
+
+	/**
+	 * @return ScalarType
+	 */
+	public static function dateTime(): ScalarType
+	{
+		if (null === static::$dateTimeType) {
+			static::$dateTimeType = new DateTimeType();
+		}
+		return static::$dateTimeType;
 	}
 }

--- a/modules/graphql/definition/DateTimeType.php
+++ b/modules/graphql/definition/DateTimeType.php
@@ -43,8 +43,7 @@ class DateTimeType extends ScalarType
 	{
 		if (!$value instanceof DateTimeInterface) {
 			throw new InvariantViolation(
-				'Входящие значение не соответствует DateTimeInterface: '
-				. Utils::printSafe($value)
+				'Входящие значение не соответствует DateTimeInterface: ' . Utils::printSafe($value)
 			);
 		}
 

--- a/modules/graphql/schema/mutations/extended/PartnerMutationType.php
+++ b/modules/graphql/schema/mutations/extended/PartnerMutationType.php
@@ -40,8 +40,7 @@ final class PartnerMutationType extends BaseMutationType
 				'id' => Type::int(),
 			],
 			'description' => 'Мутации партнёра',
-			'resolve' => fn(Partners $partner = null, array $args = []): ?Partners
-				=> Partners::findOne($args) ?? (empty($args) ? new Partners() : null),
+			'resolve' => fn(Partners $partner = null, array $args = []): ?Partners => Partners::findOne($args) ?? (empty($args) ? new Partners() : null),
 		];
 	}
 
@@ -89,15 +88,13 @@ final class PartnerMutationType extends BaseMutationType
 					'type' => ErrorTypes::validationErrorsUnionType(QueryTypes::partner()),
 					'description' => 'Обновление партнера',
 					'args' => $this->getArgs(),
-					'resolve' => fn(Partners $partner, array $args = []): array
-						=> $this->save($partner, $args, self::MESSAGES),
+					'resolve' => fn(Partners $partner, array $args = []): array => $this->save($partner, $args, self::MESSAGES),
 				],
 				'create' => [
 					'type' => ErrorTypes::validationErrorsUnionType(QueryTypes::partner()),
 					'description' => 'Создание партнера',
 					'args' => $this->getArgs(),
-					'resolve' => fn(Partners $partner, array $args = []): array
-						=> $this->save($partner, $args, self::MESSAGES),
+					'resolve' => fn(Partners $partner, array $args = []): array => $this->save($partner, $args, self::MESSAGES),
 				],
 			]
 		];

--- a/modules/graphql/schema/mutations/extended/ProductMutationType.php
+++ b/modules/graphql/schema/mutations/extended/ProductMutationType.php
@@ -8,6 +8,7 @@ use app\modules\graphql\base\BaseMutationType;
 use app\modules\graphql\data\ErrorTypes;
 use app\modules\graphql\data\MutationTypes;
 use app\modules\graphql\data\QueryTypes;
+use app\modules\graphql\definition\DateTimeType;
 use GraphQL\Type\Definition\Type;
 
 /**
@@ -26,7 +27,9 @@ final class ProductMutationType extends BaseMutationType
 	 */
 	public function __construct()
 	{
-		parent::__construct($this->getConfig());
+		parent::__construct(
+			$this->getConfig()
+		);
 	}
 
 	/**
@@ -40,8 +43,7 @@ final class ProductMutationType extends BaseMutationType
 				'id' => Type::int(),
 			],
 			'description' => 'Мутации продуктов',
-			'resolve' => fn(Products $product = null, array $args = []): ?Products
-				=> Products::findOne($args) ?? (empty($args) ? new Products() : null),
+			'resolve' => fn(Products $product = null, array $args = []): ?Products => Products::findOne($args) ?? (empty($args) ? new Products() : null),
 		];
 	}
 
@@ -68,11 +70,11 @@ final class ProductMutationType extends BaseMutationType
 				'description' => 'Периодичность списания',
 			],
 			'start_date' => [
-				'type' => Type::string(),
+				'type' => DateTimeType::dateTime(),
 				'description' => 'Начало действия Y-m-d H:i:s',
 			],
 			'end_date' => [
-				'type' => Type::string(),
+				'type' => DateTimeType::dateTime(),
 				'description' => 'Конец действия Y-m-d H:i:s',
 			],
 			'description' => [
@@ -97,8 +99,7 @@ final class ProductMutationType extends BaseMutationType
 					'type' => ErrorTypes::validationErrorsUnionType(QueryTypes::product()),
 					'description' => 'Обновление продукта',
 					'args' => $this->getArgs(),
-					'resolve' => fn(Products $product, array $args = []): array
-						=> $this->save($product, $args, self::MESSAGES),
+					'resolve' => fn(Products $product, array $args = []): array => $this->save($product, $args, self::MESSAGES),
 				],
 			]
 		];

--- a/modules/graphql/schema/mutations/extended/SubscriptionMutationType.php
+++ b/modules/graphql/schema/mutations/extended/SubscriptionMutationType.php
@@ -45,8 +45,7 @@ final class SubscriptionMutationType extends BaseMutationType
 				'id' => Type::int(),
 			],
 			'description' => 'Мутации подписок',
-			'resolve' => fn(Subscriptions $subscription = null, array $args = []): ?Subscriptions
-				=> Subscriptions::findOne($args) ?? (empty($args) ? new Subscriptions() : null),
+			'resolve' => fn(Subscriptions $subscription = null, array $args = []): ?Subscriptions => Subscriptions::findOne($args) ?? (empty($args) ? new Subscriptions() : null),
 		];
 	}
 

--- a/modules/graphql/schema/query/extended/ProductType.php
+++ b/modules/graphql/schema/query/extended/ProductType.php
@@ -12,8 +12,10 @@ use app\models\subscriptions\EnumSubscriptionTrialUnits;
 use app\modules\graphql\base\BaseQueryType;
 use app\modules\graphql\data\EnumTypes;
 use app\modules\graphql\data\QueryTypes;
+use app\modules\graphql\definition\DateTimeType;
 use GraphQL\Type\Definition\Type;
 use yii\helpers\ArrayHelper;
+use DateTimeImmutable;
 
 /**
  * Class ProductType
@@ -45,18 +47,22 @@ final class ProductType extends BaseQueryType
 					'description' => 'Описание',
 				],
 				'start_date' => [
-					'type' => Type::string(),
+					'type' => DateTimeType::dateTime(),
 					'description' => 'Начало действия Y-m-d H:i:s',
+					'resolve' => fn(Products $products): ?DateTimeImmutable => DateTimeType::parseString($products->start_date)
 				],
 				'end_date' => [
-					'type' => Type::string(),
+					'type' => DateTimeType::dateTime(),
 					'description' => 'Конец действия Y-m-d H:i:s',
+					'resolve' => fn(Products $products): ?DateTimeImmutable => DateTimeType::parseString($products->end_date)
 				],
 				'payment_period' => [
 					'type' => EnumTypes::productPaymentPeriodType(),
 					'description' => 'Периодичность списания',
-					'resolve' => fn(Products $product): ?array
-						=> self::getOneFromEnum(EnumProductsPaymentPeriods::mapData(), ['id' => $product->payment_period]),
+					'resolve' => fn(Products $product): ?array => self::getOneFromEnum(
+						EnumProductsPaymentPeriods::mapData(),
+						['id' => $product->payment_period]
+					),
 				],
 				'type_id' => [
 					'type' => Type::int(),
@@ -65,8 +71,10 @@ final class ProductType extends BaseQueryType
 				'type' => [
 					'type' => EnumTypes::productTypesType(),
 					'description' => 'Тип продукта',
-					'resolve' => fn(Products $product): ?array
-						=> self::getOneFromEnum(EnumProductsTypes::mapData(), ['id' => $product->type_id]),
+					'resolve' => fn(Products $product): ?array => self::getOneFromEnum(
+						EnumProductsTypes::mapData(),
+						['id' => $product->type_id]
+					),
 				],
 				'partner_id' => [
 					'type' => Type::int(),
@@ -85,12 +93,15 @@ final class ProductType extends BaseQueryType
 				'trial_unit' => [
 					'type' => EnumTypes::subscriptionTrialUnitsType(),
 					'description' => 'Единица измерения триального периода',
-					'resolve' => fn(Products $product): ?array
-						=> self::getOneFromEnum(EnumSubscriptionTrialUnits::mapData(), ['id' => $product->relatedInstance->units ?? 0]),
+					'resolve' => fn(Products $product): ?array => self::getOneFromEnum(
+						EnumSubscriptionTrialUnits::mapData(),
+						['id' => $product->relatedInstance->units ?? 0]
+					),
 				],
 				'created_at' => [
-					'type' => Type::string(),
+					'type' => DateTimeType::dateTime(),
 					'description' => 'Дата создания Y-m-d H:i:s',
+					'resolve' => fn(Products $products): ?DateTimeImmutable => DateTimeType::parseString($products->created_at),
 				],
 			],
 		]);
@@ -147,8 +158,7 @@ final class ProductType extends BaseQueryType
 				'id' => Type::nonNull(Type::int()),
 			],
 			'description' => 'Возвращает продукт по id',
-			'resolve' => fn(Products $product = null, array $args = []): ?Products
-				=> Products::find()->where($args)->active()->one(),
+			'resolve' => fn(Products $product = null, array $args = []): ?Products => Products::find()->where($args)->active()->one(),
 		];
 	}
 }

--- a/modules/graphql/schema/query/extended/ServerDateTimeType.php
+++ b/modules/graphql/schema/query/extended/ServerDateTimeType.php
@@ -3,8 +3,10 @@ declare(strict_types = 1);
 
 namespace app\modules\graphql\schema\query\extended;
 
+use app\modules\graphql\definition\DateTimeType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
+use DateTimeImmutable;
 
 /**
  * Служебный класс для данных даты.
@@ -34,9 +36,11 @@ final class ServerDateTimeType extends ObjectType
 	public static function baseFormat(): array
 	{
 		return [
-			'type' => Type::string(),
+			'type' => DateTimeType::dateTime(),
 			'description' => 'Серверное время в формате Y-m-d H:i:s',
-			'resolve' => fn(?array $root, array $args): string => date('Y-m-d H:i:s'),
+			'resolve' => fn(?array $root, array $args): DateTimeImmutable => DateTimeType::parseString(
+				date('Y-m-d H:i:s')
+			),
 		];
 	}
 }

--- a/modules/graphql/schema/query/extended/SubscriptionType.php
+++ b/modules/graphql/schema/query/extended/SubscriptionType.php
@@ -40,8 +40,10 @@ final class SubscriptionType extends BaseQueryType
 				'units' => [
 					'type' => EnumTypes::subscriptionTrialUnitsType(),
 					'description' => 'Единица измерения триального периода',
-					'resolve' => fn(Subscriptions $subscription): ?array
-						=> self::getOneFromEnum(EnumSubscriptionTrialUnits::mapData(), ['id' => $subscription->units]),
+					'resolve' => fn(Subscriptions $subscription): ?array => self::getOneFromEnum(
+						EnumSubscriptionTrialUnits::mapData(),
+						['id' => $subscription->units]
+					),
 				],
 				'product' => [
 					'type' => QueryTypes::product(),

--- a/modules/graphql/schema/query/extended/enum/FormPartnersType.php
+++ b/modules/graphql/schema/query/extended/enum/FormPartnersType.php
@@ -11,26 +11,18 @@ use GraphQL\Type\Definition\EnumType;
  */
 class FormPartnersType extends EnumType
 {
-	public const NAME			= 'name';
-	public const INN			= 'inn';
-	public const PHONE 			= 'phone';
-	public const EMAIL			= 'email';
-	public const COMMENT		= 'comment';
-	public const CATEGORY_ID	= 'category_id';
-	public const LOGO			= 'logo';
-
 	public function __construct()
 	{
 		parent::__construct([
 			'name' => 'FormPartners',
 			'values' => [
-				self::NAME,
-				self::INN,
-				self::PHONE,
-				self::EMAIL,
-				self::COMMENT,
-				self::CATEGORY_ID,
-				self::LOGO,
+				'name',
+				'inn',
+				'phone',
+				'email',
+				'comment',
+				'category_id',
+				'logo',
 			],
 		]);
 	}

--- a/modules/graphql/schema/query/extended/enum/FormPartnersType.php
+++ b/modules/graphql/schema/query/extended/enum/FormPartnersType.php
@@ -17,6 +17,7 @@ class FormPartnersType extends EnumType
 	public const EMAIL			= 'email';
 	public const COMMENT		= 'comment';
 	public const CATEGORY_ID	= 'category_id';
+	public const LOGO			= 'logo';
 
 	public function __construct()
 	{
@@ -29,6 +30,7 @@ class FormPartnersType extends EnumType
 				self::EMAIL,
 				self::COMMENT,
 				self::CATEGORY_ID,
+				self::LOGO,
 			],
 		]);
 	}

--- a/modules/graphql/schema/query/extended/enum/FormPartnersType.php
+++ b/modules/graphql/schema/query/extended/enum/FormPartnersType.php
@@ -22,7 +22,7 @@ class FormPartnersType extends EnumType
 	public function __construct()
 	{
 		parent::__construct([
-			'name' => 'FormPartners',
+			'name' => 'FormPartnersField',
 			'values' => [
 				self::NAME,
 				self::INN,

--- a/modules/graphql/schema/query/extended/enum/FormPartnersType.php
+++ b/modules/graphql/schema/query/extended/enum/FormPartnersType.php
@@ -11,18 +11,26 @@ use GraphQL\Type\Definition\EnumType;
  */
 class FormPartnersType extends EnumType
 {
+	public const NAME			= 'name';
+	public const INN			= 'inn';
+	public const PHONE 			= 'phone';
+	public const EMAIL			= 'email';
+	public const COMMENT		= 'comment';
+	public const CATEGORY_ID	= 'category_id';
+	public const LOGO			= 'logo';
+
 	public function __construct()
 	{
 		parent::__construct([
 			'name' => 'FormPartners',
 			'values' => [
-				'name',
-				'inn',
-				'phone',
-				'email',
-				'comment',
-				'category_id',
-				'logo',
+				self::NAME,
+				self::INN,
+				self::PHONE,
+				self::EMAIL,
+				self::COMMENT,
+				self::CATEGORY_ID,
+				self::LOGO,
 			],
 		]);
 	}


### PR DESCRIPTION
Ребята с фронта попросили реализовать DateTime для GraphQL. В webonyx/graphql нет типа DateTime, пришлось написать свой, на основе ScalarType.